### PR TITLE
Use Variant Quantity 

### DIFF
--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -8,7 +8,7 @@ module Spree
                                                 .reject(&:pending?)
                                                 .sum(&:quantity)
 
-          return if unit_count >= line_item.quantity
+          return if unit_count >= variant_quantity
 
           quantity = variant_quantity - unit_count
           return if quantity.zero?


### PR DESCRIPTION
Use the provided variant quantity, rather than the line item.