### PR TITLE
Add tracking for after core 4.1

### DIFF
--- a/app/models/spree/stock/inventory_unit_builder_decorator.rb
+++ b/app/models/spree/stock/inventory_unit_builder_decorator.rb
@@ -4,8 +4,10 @@ module Spree
       def units
         @order.line_items.flat_map do |line_item|
           line_item.quantity_by_variant.flat_map do |variant, quantity|
-            if Gem.loaded_specs['spree_core'].version >= Gem::Version.create('3.3.0')
+            if Gem.loaded_specs['spree_core'].version >= Gem::Version.create('4.1.0')
               build_inventory_unit(variant, line_item, quantity)
+            elsif Gem.loaded_specs['spree_core'].version >= Gem::Version.create('3.3.0')
+              build_inventory_unit_3_3_0(variant, line_item, quantity)
             else
               quantity.times.map { build_inventory_unit(variant, line_item) }
             end
@@ -14,6 +16,18 @@ module Spree
       end
 
       def build_inventory_unit(variant, line_item, quantity=nil)
+        # They go through multiple splits, avoid loading the
+        # association to order until needed.
+        Spree::InventoryUnit.new(
+          pending: true,
+          line_item_id: line_item.id,
+          variant_id: variant.id,
+          quantity: quantity,
+          order_id: @order.id
+        )
+      end
+
+      def build_inventory_unit_3_3_0(variant, line_item, quantity=nil)
         @order.inventory_units.includes(
           variant: {
             product: {


### PR DESCRIPTION
This will now track inventory units with the correct tracker rather than just adding them like old spree versions.