### PR TITLE
Fix multiple product sales

### DIFF
--- a/app/models/spree/stock/packer_decorator.rb
+++ b/app/models/spree/stock/packer_decorator.rb
@@ -1,0 +1,32 @@
+module Spree
+  module Stock
+    module PackerDecorator
+      # Overriding the default packager
+      def default_package
+        package = Package.new(stock_location)
+
+        # Group by variant_id as grouping by variant fires cached query.
+        inventory_units.index_by do |unit|
+          { variant_id: unit.variant_id, line_item_id: unit.line_item_id }
+        end.each do |indices, inventory_unit|
+          variant = Spree::Variant.find(indices[:variant_id])
+          unit = inventory_unit.dup # Can be used by others, do not use directly
+
+          if variant.should_track_inventory?
+            next unless stock_location.stocks? variant
+
+            on_hand, backordered = stock_location.fill_status(variant, unit.quantity)
+            package.add(InventoryUnit.split(unit, backordered), :backordered) if backordered.positive?
+            package.add(InventoryUnit.split(unit, on_hand), :on_hand) if on_hand.positive?
+          else
+            package.add unit
+          end
+        end
+
+        package
+      end
+    end
+  end
+end
+
+Spree::Stock::Packer.prepend Spree::Stock::PackerDecorator

--- a/app/models/spree/stock/prioritizer_decorator.rb
+++ b/app/models/spree/stock/prioritizer_decorator.rb
@@ -1,0 +1,21 @@
+module Spree
+  module Stock
+    module PrioritizerDecorator
+      def hash_item(item)
+        shipment = item.inventory_unit.shipment
+        variant  = item.inventory_unit.variant
+        line_item  = item.inventory_unit.line_item
+
+        hash = if shipment.present?
+                 variant.hash ^ shipment.hash
+               else
+                 variant.hash
+               end
+
+        hash ^ line_item.hash if line_item.present?
+      end
+    end
+  end
+end
+
+Spree::Stock::Prioritizer.prepend Spree::Stock::PrioritizerDecorator

--- a/app/services/spree/cart/add_item_decorator.rb
+++ b/app/services/spree/cart/add_item_decorator.rb
@@ -10,7 +10,6 @@ module Spree::Cart::AddItemDecorator
 
     line_item_created = line_item.nil?
     if line_item_created
-      ap "LINE ITEM CREATE???"
       opts = ::Spree::PermittedAttributes.line_item_attributes.flatten.each_with_object({}) do |attribute, result|
         result[attribute] = options[attribute]
       end.merge(currency: order.currency).merge(whitelist(options)).delete_if { |_key, value| value.nil? }


### PR DESCRIPTION
This fixes the issue brought up in: https://github.com/spree-contrib/spree-product-assembly/issues/207
This now allows bundles and single items to sell together as it takes the line item into consideration.