### PR TITLE
Fix Coordinator Quantity

### DIFF
--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -6,9 +6,13 @@ module Spree::InventoryUnitDecorator
                            original_return_item.return_quantity
                          else
                            if line_item.product.assembly?
-                             part_count = line_item.part_line_items
-                                                   .where(variant_id: variant.id)
-                                                   .sum(&:quantity)
+                             part_count = if line_item.part_line_items.any?
+                                            line_item.part_line_items
+                                                     .where(variant_id: variant.id)
+                                                     .sum(&:quantity)
+                                          else
+                                            line_item.count_of(variant)
+                                          end
 
                              line_item.quantity * part_count
                            else

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_product_assembly'
-  s.version     = '4.1.4'
+  s.version     = '4.1.2'
   s.summary     = 'Adds oportunity to make bundle of products to your Spree store'
   s.description = s.summary
   s.required_ruby_version = '>= 2.1.0'


### PR DESCRIPTION
We can use `count_of` if there is no part_line_item.